### PR TITLE
Switch default WM to i3, add Galaxy badges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,10 @@ Installed via `ansible-galaxy install -r requirements.yml`:
 |---|---|
 | `jahrik.yay` | AUR helper (Arch only) |
 | `jahrik.alacritty` | Terminal emulator + config |
-| `jahrik.sway` | Wayland compositor + config |
+| `jahrik.i3_gaps` | i3-gaps window manager + config |
+| `jahrik.polybar` | Status bar |
+| `jahrik.urxvt` | X11 terminal emulator |
+| `jahrik.conky` | System monitor / i3 bar widget |
 | `jahrik.zsh` | Shell + Oh My Zsh |
 | `jahrik.vim` | Vim + Vundle + plugins |
 | `jahrik.nvim` | Neovim + Packer + LSP |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Arch Workstation
 
 [![CICD](https://github.com/jahrik/ansible-arch-workstation/actions/workflows/cicd.yml/badge.svg)](https://github.com/jahrik/ansible-arch-workstation/actions/workflows/cicd.yml)
+[![Ansible Galaxy](https://img.shields.io/ansible/role/d/13941)](https://galaxy.ansible.com/ui/standalone/roles/13941/)
+[![Ansible Quality Score](https://img.shields.io/ansible/quality/13941)](https://galaxy.ansible.com/ui/standalone/roles/13941/)
 
 Setup an Arch Linux development environment
 
@@ -26,7 +28,7 @@ Setup an Arch Linux development environment
 
 ## Requirements
 
-This role is intended for setting a development environment on fresh install of Arch Linux. It is a collection of roles that install things like sway, nvim, and zsh. 
+This role is intended for setting a development environment on fresh install of Arch Linux. It is a collection of roles that install things like i3-gaps, nvim, and zsh.
 
 ## Role Variables
 
@@ -55,9 +57,12 @@ This role is intended for setting a development environment on fresh install of 
       - sudo
       - git
 
-    # sway configs
-    sway:
-      bar: waybar
+    # i3 configs (default WM; swap tasks/main.yml roles to use jahrik.sway instead)
+    i3:
+      lock: true
+      bar: false    # false = polybar, true = conky i3bar
+      polybar: true
+      terminal: alacritty
 
     # Python/Ansible color output
     python_force_color: 1
@@ -65,12 +70,17 @@ This role is intended for setting a development environment on fresh install of 
 
 ## Dependencies
 
-- jahrik.alacritty
-- jahrik.nvim
-- jahrik.sway
-- jahrik.vim
-- jahrik.yay
-- jahrik.zsh
+| Role | Galaxy |
+|------|--------|
+| jahrik.yay | [![Downloads](https://img.shields.io/ansible/role/d/13942)](https://galaxy.ansible.com/ui/standalone/roles/13942/) [![Quality](https://img.shields.io/ansible/quality/13942)](https://galaxy.ansible.com/ui/standalone/roles/13942/) |
+| jahrik.alacritty | [![Downloads](https://img.shields.io/ansible/role/d/13932)](https://galaxy.ansible.com/ui/standalone/roles/13932/) [![Quality](https://img.shields.io/ansible/quality/13932)](https://galaxy.ansible.com/ui/standalone/roles/13932/) |
+| jahrik.i3_gaps | [![Downloads](https://img.shields.io/ansible/role/d/13935)](https://galaxy.ansible.com/ui/standalone/roles/13935/) [![Quality](https://img.shields.io/ansible/quality/13935)](https://galaxy.ansible.com/ui/standalone/roles/13935/) |
+| jahrik.polybar | [![Downloads](https://img.shields.io/ansible/role/d/13937)](https://galaxy.ansible.com/ui/standalone/roles/13937/) [![Quality](https://img.shields.io/ansible/quality/13937)](https://galaxy.ansible.com/ui/standalone/roles/13937/) |
+| jahrik.urxvt | [![Downloads](https://img.shields.io/ansible/role/d/13939)](https://galaxy.ansible.com/ui/standalone/roles/13939/) [![Quality](https://img.shields.io/ansible/quality/13939)](https://galaxy.ansible.com/ui/standalone/roles/13939/) |
+| jahrik.conky | [![Downloads](https://img.shields.io/ansible/role/d/13933)](https://galaxy.ansible.com/ui/standalone/roles/13933/) [![Quality](https://img.shields.io/ansible/quality/13933)](https://galaxy.ansible.com/ui/standalone/roles/13933/) |
+| jahrik.zsh | [![Downloads](https://img.shields.io/ansible/role/d/13943)](https://galaxy.ansible.com/ui/standalone/roles/13943/) [![Quality](https://img.shields.io/ansible/quality/13943)](https://galaxy.ansible.com/ui/standalone/roles/13943/) |
+| jahrik.vim | [![Downloads](https://img.shields.io/ansible/role/d/13940)](https://galaxy.ansible.com/ui/standalone/roles/13940/) [![Quality](https://img.shields.io/ansible/quality/13940)](https://galaxy.ansible.com/ui/standalone/roles/13940/) |
+| jahrik.nvim | [![Downloads](https://img.shields.io/ansible/role/d/13936)](https://galaxy.ansible.com/ui/standalone/roles/13936/) [![Quality](https://img.shields.io/ansible/quality/13936)](https://galaxy.ansible.com/ui/standalone/roles/13936/) |
 
 ## Example Playbook
 
@@ -136,7 +146,7 @@ This repository is the first thing I clone any time I reinstall Arch on a new la
     iwctl
     station list
     station wlan0 scan
-    statoin wlan0 get-networks
+    station wlan0 get-networks
     station wlan0 connect <NETWORK>
 
 ### Arch Install

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ plugins:
   - git
   - sudo
 
-# i3
+# i3 (default window manager; swap tasks/main.yml roles to use jahrik.sway instead)
 text:
   font: DejaVuSansMono Nerd Font Mono
   size: 18

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: Installs a development workstation
   company: https://homelab.business
   issue_tracker_url: https://github.com/jahrik/ansible-arch-workstation/issues
-  min_ansible_version: '2.1'
+  min_ansible_version: '2.16'
   license: GPLv2
   platforms:
     - name: ArchLinux
@@ -27,10 +27,11 @@ galaxy_info:
 
 dependencies:
   - role: jahrik.yay
-  - role: jahrik.vim
-  - role: jahrik.zsh
+  - role: jahrik.alacritty
   - role: jahrik.i3_gaps
   - role: jahrik.polybar
   - role: jahrik.urxvt
-  - role: jahrik.alacritty
   - role: jahrik.conky
+  - role: jahrik.zsh
+  - role: jahrik.vim
+  - role: jahrik.nvim

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,14 @@
 ---
 collections:
   - name: community.general
+
+roles:
+  - name: jahrik.alacritty
+  - name: jahrik.conky
+  - name: jahrik.i3_gaps
+  - name: jahrik.nvim
+  - name: jahrik.polybar
+  - name: jahrik.urxvt
+  - name: jahrik.vim
+  - name: jahrik.yay
+  - name: jahrik.zsh

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -32,3 +32,53 @@
       ansible.builtin.assert:
         that: zsh_bin.stat.exists
         fail_msg: "zsh binary not found at /usr/bin/zsh"
+
+    - name: Check i3 binary
+      ansible.builtin.stat:
+        path: /usr/bin/i3
+      register: i3_bin
+
+    - name: Assert i3 is installed
+      ansible.builtin.assert:
+        that: i3_bin.stat.exists
+        fail_msg: "i3 binary not found at /usr/bin/i3"
+
+    - name: Check polybar binary
+      ansible.builtin.stat:
+        path: /usr/bin/polybar
+      register: polybar_bin
+
+    - name: Assert polybar is installed
+      ansible.builtin.assert:
+        that: polybar_bin.stat.exists
+        fail_msg: "polybar binary not found at /usr/bin/polybar"
+
+    - name: Check urxvt binary
+      ansible.builtin.stat:
+        path: /usr/bin/urxvt
+      register: urxvt_bin
+
+    - name: Assert urxvt is installed
+      ansible.builtin.assert:
+        that: urxvt_bin.stat.exists
+        fail_msg: "urxvt binary not found at /usr/bin/urxvt"
+
+    - name: Check vim binary
+      ansible.builtin.stat:
+        path: /usr/bin/vim
+      register: vim_bin
+
+    - name: Assert vim is installed
+      ansible.builtin.assert:
+        that: vim_bin.stat.exists
+        fail_msg: "vim binary not found at /usr/bin/vim"
+
+    - name: Check nvim binary
+      ansible.builtin.stat:
+        path: /usr/bin/nvim
+      register: nvim_bin
+
+    - name: Assert nvim is installed
+      ansible.builtin.assert:
+        that: nvim_bin.stat.exists
+        fail_msg: "nvim binary not found at /usr/bin/nvim"

--- a/molecule/vagrant/converge.yml
+++ b/molecule/vagrant/converge.yml
@@ -1,7 +1,5 @@
 ---
 - name: Converge
   hosts: all
-  tasks:
-    - name: "Include jahrik.workstation"
-      include_role:
-        name: "jahrik.workstation"
+  roles:
+    - role: jahrik.workstation

--- a/molecule/vagrant/molecule.yml
+++ b/molecule/vagrant/molecule.yml
@@ -17,8 +17,7 @@ platforms:
       synced_folder: true
     instance_raw_config_args:
       - 'vm.provision :shell, inline: "pacman --noconfirm -Syu"'
-      - 'vm.provision :shell, inline: "pacman --noconfirm -S python base-devel"'
-      # - 'vm.provision :shell, inline: "pacman --noconfirm -S wayland xorg-xwayland"'
+      - 'vm.provision :shell, inline: "pacman --noconfirm -S python base-devel xorg-server xorg-xinit"'
 provisioner:
   name: ansible
 verifier:

--- a/molecule/vagrant/requirements.yml
+++ b/molecule/vagrant/requirements.yml
@@ -1,0 +1,11 @@
+---
+roles:
+  - name: jahrik.alacritty
+  - name: jahrik.conky
+  - name: jahrik.i3_gaps
+  - name: jahrik.nvim
+  - name: jahrik.polybar
+  - name: jahrik.urxvt
+  - name: jahrik.vim
+  - name: jahrik.yay
+  - name: jahrik.zsh

--- a/molecule/vagrant/verify.yml
+++ b/molecule/vagrant/verify.yml
@@ -1,10 +1,84 @@
 ---
-# This is an example playbook to execute Ansible tests.
-
 - name: Verify
   hosts: all
   gather_facts: false
   tasks:
-  - name: Example assertion
-    assert:
-      that: true
+    - name: Check yay binary
+      ansible.builtin.stat:
+        path: /usr/bin/yay
+      register: yay_bin
+
+    - name: Assert yay is installed
+      ansible.builtin.assert:
+        that: yay_bin.stat.exists
+        fail_msg: "yay binary not found at /usr/bin/yay"
+
+    - name: Check alacritty binary
+      ansible.builtin.stat:
+        path: /usr/bin/alacritty
+      register: alacritty_bin
+
+    - name: Assert alacritty is installed
+      ansible.builtin.assert:
+        that: alacritty_bin.stat.exists
+        fail_msg: "alacritty binary not found at /usr/bin/alacritty"
+
+    - name: Check i3 binary
+      ansible.builtin.stat:
+        path: /usr/bin/i3
+      register: i3_bin
+
+    - name: Assert i3 is installed
+      ansible.builtin.assert:
+        that: i3_bin.stat.exists
+        fail_msg: "i3 binary not found at /usr/bin/i3"
+
+    - name: Check polybar binary
+      ansible.builtin.stat:
+        path: /usr/bin/polybar
+      register: polybar_bin
+
+    - name: Assert polybar is installed
+      ansible.builtin.assert:
+        that: polybar_bin.stat.exists
+        fail_msg: "polybar binary not found at /usr/bin/polybar"
+
+    - name: Check urxvt binary
+      ansible.builtin.stat:
+        path: /usr/bin/urxvt
+      register: urxvt_bin
+
+    - name: Assert urxvt is installed
+      ansible.builtin.assert:
+        that: urxvt_bin.stat.exists
+        fail_msg: "urxvt binary not found at /usr/bin/urxvt"
+
+    - name: Check zsh binary
+      ansible.builtin.stat:
+        path: /usr/bin/zsh
+      register: zsh_bin
+
+    - name: Assert zsh is installed
+      ansible.builtin.assert:
+        that: zsh_bin.stat.exists
+        fail_msg: "zsh binary not found at /usr/bin/zsh"
+
+    - name: Check vim binary
+      ansible.builtin.stat:
+        path: /usr/bin/vim
+      register: vim_bin
+
+    - name: Assert vim is installed
+      ansible.builtin.assert:
+        that: vim_bin.stat.exists
+        fail_msg: "vim binary not found at /usr/bin/vim"
+
+    - name: Check nvim binary
+      ansible.builtin.stat:
+        path: /usr/bin/nvim
+      register: nvim_bin
+
+    - name: Assert nvim is installed
+      ansible.builtin.assert:
+        that: nvim_bin.stat.exists
+        fail_msg: "nvim binary not found at /usr/bin/nvim"

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,6 @@
 - name: jahrik.i3_gaps
 - name: jahrik.nvim
 - name: jahrik.polybar
-- name: jahrik.sway
 - name: jahrik.urxvt
 - name: jahrik.vim
 - name: jahrik.yay

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,9 +8,21 @@
   ansible.builtin.include_role:
     name: jahrik.alacritty
 
-- name: Install and configure Sway
+- name: Install and configure i3-gaps
   ansible.builtin.include_role:
-    name: jahrik.sway
+    name: jahrik.i3_gaps
+
+- name: Install and configure polybar
+  ansible.builtin.include_role:
+    name: jahrik.polybar
+
+- name: Install urxvt
+  ansible.builtin.include_role:
+    name: jahrik.urxvt
+
+- name: Install and configure conky
+  ansible.builtin.include_role:
+    name: jahrik.conky
 
 - name: Install and configure zsh and set as default user shell
   ansible.builtin.include_role:


### PR DESCRIPTION
## Summary

- Switch default window manager from sway back to i3: replace `jahrik.sway` with the full i3 stack (`jahrik.i3_gaps`, `jahrik.polybar`, `jahrik.urxvt`, `jahrik.conky`) in `tasks/main.yml` and `requirements.yml`
- Update `meta/main.yml`: add `jahrik.nvim` dependency, reorder to match task execution order, bump `min_ansible_version` from `2.1` to `2.16`
- Add Galaxy role installs to `molecule/default/requirements.yml` so CI can resolve sub-role dependencies during molecule prerun
- Expand `molecule/default/verify.yml` with assertions for i3, polybar, urxvt, vim, and nvim binaries
- Add Galaxy download count + quality score badges to README for this role and all 9 sub-roles (IDs fetched from Galaxy API)
- Fix stale sway references in README and `defaults/main.yml`; fix `station` typo in WiFi section

## Test plan

- [x] `molecule test` passed locally (all verify assertions green, full converge + idempotence + verify + destroy)
- [x] `yamllint .` clean
- [x] `ansible-lint` clean (production profile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)