### PR TITLE
Add pull: true to Arch molecule platform; modernize Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,23 +1,40 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-VAGRANTFILE_API_VERSION = "2"
-
-Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "archlinux/archlinux"
-  config.vm.provider :virtualbox do |vb|
-    vb.cpus = 2
-    vb.gui = true
-    vb.customize ["modifyvm", :id, "--memory", "4096"]
-    vb.customize ["modifyvm", :id, "--cpus", "2"]
-    vb.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
-    vb.customize ["modifyvm", :id, "--vram", "256"]
-  end
+Vagrant.configure("2") do |config|
+  config.vm.box = "cloud-image/arch-linux"
+  config.vm.hostname = "archie.dev"
   config.ssh.forward_x11 = true
-  config.vm.network 'private_network', ip: '192.168.56.11'
-  config.vm.hostname = 'archie.dev'
-  config.vm.provision "shell", inline: %{
+  config.vm.synced_folder ".", "/vagrant", type: "rsync",
+    rsync__exclude: [".git/", ".vagrant/", ".ansible/"]
+
+  config.vm.provider :qemu do |qemu|
+    qemu_bin_dirs = ["/usr/bin", "/opt/homebrew/bin", "/usr/local/bin"]
+    qemu.qemu_dir = qemu_bin_dirs.find { |d| File.exist?("#{d}/qemu-system-x86_64") } || "/usr/bin"
+    qemu.memory = "4096M"
+    qemu.cpus = 2
+    qemu.arch = "x86_64"
+    qemu.machine = "q35"
+    qemu.cpu = "host"
+    qemu.net_device = "virtio-net-pci"
+    qemu.extra_qemu_args = File.exist?("/dev/kvm") ? %w(-enable-kvm) : []
+  end
+
+  config.vm.provider :virtualbox do |vb|
+    vb.memory = 4096
+    vb.cpus = 2
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
     pacman --noconfirm -Syu
-    pacman --noconfirm -S xorg-server xorg-xinit xorg-xrandr
-  }
+    pacman --noconfirm -S git ansible python xorg-server xorg-xinit xorg-xrandr
+    mkdir -p /etc/ansible/roles
+    ln -sf /vagrant /etc/ansible/roles/jahrik.workstation
+    ansible-galaxy install -r /vagrant/requirements.yml -p /etc/ansible/roles
+  SHELL
+
+  config.vm.provision "ansible_local" do |ansible|
+    ansible.playbook = "playbook.yml"
+    ansible.install = false
+  end
 end

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,6 +7,7 @@ platforms:
   - name: arch
     image: jahrik/docker-archlinux-ansible
     pre_build_image: true
+    pull: true
 provisioner:
   name: ansible
   inventory:


### PR DESCRIPTION
## Summary
- Add `pull: true` to `molecule/default/molecule.yml` Arch platform so CI always fetches the latest rolling image
- Update Vagrantfile to support QEMU provider alongside VirtualBox (Arch `cloud-image` box, KVM acceleration, virtio networking)

## Test plan
- [x] Lint ✅
- [x] Molecule ✅
- [x] CI run green