### PR TITLE
Update role: ansible-arch-workstation — migrate to ansible_facts

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
+inject_facts_as_vars = False
 
 inventory      = inventory.ini
 #library        = /usr/share/my_modules/

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -8,4 +8,4 @@
         upgrade: true
         update_cache: true
       changed_when: false
-      when: ansible_os_family == 'Archlinux'
+      when: ansible_facts['os_family'] == 'Archlinux'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Install yay for easy AUR package installs
   ansible.builtin.include_role:
     name: jahrik.yay
-  when: ansible_os_family == 'Archlinux'
+  when: ansible_facts['os_family'] == 'Archlinux'
 
 - name: Install alacritty
   ansible.builtin.include_role:


### PR DESCRIPTION
## Summary
- Migrate `ansible_<fact>` magic variables to bracket-style `ansible_facts['<fact>']`.
- Add `ansible.cfg` (`inject_facts_as_vars = False`) to disable injected magic vars and require explicit `ansible_facts` access.


## Test plan
- [x] `yamllint .` clean
- [x] `ansible-lint` clean (profile: production)
- [x] Local `molecule test` PASS — converge + idempotence (changed=0) + verify green on Ubuntu 26.04 + Arch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)