### PR TITLE
chore: refresh uv.lock to match bumped tooling constraints

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -20,10 +20,10 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ansible-core", specifier = ">=2.16,<2.22" },
-    { name = "ansible-lint", specifier = ">=24.0.0" },
-    { name = "molecule", specifier = ">=24.0.0" },
-    { name = "molecule-plugins", extras = ["docker"], specifier = ">=23.0.0" },
+    { name = "ansible-core", specifier = ">=2.21.1,<2.22" },
+    { name = "ansible-lint", specifier = ">=26.6.0" },
+    { name = "molecule", specifier = ">=26.6.0" },
+    { name = "molecule-plugins", extras = ["docker"], specifier = ">=25.8.12" },
     { name = "yamllint", specifier = ">=1.38.0" },
 ]
 
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "ansible-lint"
-version = "26.4.0"
+version = "26.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ansible-compat" },
@@ -82,9 +82,9 @@ dependencies = [
     { name = "wcmatch" },
     { name = "yamllint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/39/54f7cc264f7f02c635af786c4a57da4ab993865140f90e031cdec39dd514/ansible_lint-26.4.0.tar.gz", hash = "sha256:29e0438f8af685a4fec96f9ea3404a3beb50d2911bc8df43f283256954ceea5b", size = 736853 }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/e5/547e64cf118392fb4d02c179eb0cd86b06145bf7c8e18ab49cc6de5e9886/ansible_lint-26.6.0.tar.gz", hash = "sha256:790d08ff6ee56525244677411c90a17b374245d3913bc6a462b5d913ece6d615", size = 767696 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/97/803cde1dba6c5cc24f1401b37df8404a2793bd26dc3f11c0a9722109b859/ansible_lint-26.4.0-py3-none-any.whl", hash = "sha256:f33c4823544a5a8e5e36614866e111d1a929eeffee5e84481ede10d524a9d6d6", size = 330939 },
+    { url = "https://files.pythonhosted.org/packages/d1/66/465f210bd0ac409143d5258516bd9db5376ac86ac61707e3e4ef65b27fc4/ansible_lint-26.6.0-py3-none-any.whl", hash = "sha256:162939615eae3b59f38bd829542642b586ccee17eefb0df8718ea4b092eee222", size = 341055 },
 ]
 
 [[package]]
@@ -431,7 +431,7 @@ wheels = [
 
 [[package]]
 name = "molecule"
-version = "26.4.0"
+version = "26.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ansible-compat" },
@@ -446,9 +446,9 @@ dependencies = [
     { name = "rich" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/e0/f671b5b0742a60b6067cbe9e57720b600ded5e0fcabb837663dd21b57568/molecule-26.4.0.tar.gz", hash = "sha256:12e4c905079f67628ae765506c697d2b8a744a65f2d4cbf5a3b22cb09d0dafc4", size = 4699013 }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/81/7391315d9e10d7a37bb11d0d83d5d03303f698292465e3c1620028a3abf7/molecule-26.6.0.tar.gz", hash = "sha256:1870c5f5442403d77b5953d344382265a521eb4948885260c0cac084aa3dec02", size = 4717402 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/11/9f8322de3674b6ac12d0d203d18f81eb9262af19d2b8122c08b11821af97/molecule-26.4.0-py3-none-any.whl", hash = "sha256:b231f4955f95240a8e2b8194c086d0b5e8ab998032a9411eafe85429442a3bd5", size = 158898 },
+    { url = "https://files.pythonhosted.org/packages/80/15/cebabfd858a470e4497a7c4fa6edec16246a7b2c7cb6f937388ac4d76a59/molecule-26.6.0-py3-none-any.whl", hash = "sha256:e0d63011f1f044030a0c769178f4800271a2a8137f51124b18d673e576a88c52", size = 162387 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Dependabot PRs widened pyproject.toml constraints (ansible-lint/molecule to >=26.6.0, molecule-plugins to >=25.8.12, ansible-core to >=2.21.1,<2.22) but `uv.lock` was never regenerated, leaving it resolving stale versions (ansible-lint/molecule 26.4.0).
- Ran plain `uv lock` (no `--upgrade`) to catch the lockfile up to the already-widened ceilings only.

## Test plan
- [x] `uv lock` resolved cleanly (ansible-lint/molecule 26.4.0 -> 26.6.0)
- [x] `uv run yamllint .` passes
- [x] `uv run ansible-lint --profile production` passes (0 failures, 0 warnings)
- [x] `git diff main` touches only `uv.lock`
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)